### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Hi Jayshil,
 please add the file pyproject.toml to avoid the following depracation warning for users whenever they use pip to install any package after installing pycdata...


DEPRECATION: Loading egg at /Users/pflm/miniconda3/lib/python3.11/site-packages/pycdata-1.3.0-py3.11.egg is deprecated. pip 24.3 will enforce this behaviour change. A possible replacement is to use pip for package installation. Discussion can be found at https://github.com/pypa/pip/issues/12330

Thanks,
 -Pierre